### PR TITLE
Fixed the way of grouping orders together on the client side. Not usi…

### DIFF
--- a/lib/redux/slices/adminSlice.js
+++ b/lib/redux/slices/adminSlice.js
@@ -189,12 +189,12 @@ const adminSlice = createSlice({
       })
 
       // * We group the orders by their reference number
-      const groupedOrders = Object.groupBy(orders, order => order.orderReferenceNumber);
+      const groupedOrders = Object.groupBy(orders, order => order.paymentId);
 
       // * We convert the groupedOrders object into an array
       const groupedOrdersArray = Object.entries(groupedOrders).map(
-        ([referenceNumber, orders]) => ({
-          referenceNumber,
+        ([paymentId, orders]) => ({
+          paymentId,
           orders,
         })
       );

--- a/lib/redux/slices/orderSlice.js
+++ b/lib/redux/slices/orderSlice.js
@@ -60,12 +60,12 @@ const orderSlice = createSlice({
       })
 
       // * We group the orders by their reference number
-      const groupedOrders = Object.groupBy(orders, order => order.orderReferenceNumber);
+      const groupedOrders = Object.groupBy(orders, order => order.paymentId);
 
       // * We convert the groupedOrders object into an array
       const groupedOrdersArray = Object.entries(groupedOrders).map(
-        ([referenceNumber, orders]) => ({
-          referenceNumber,
+        ([paymentId, orders]) => ({
+          paymentId,
           orders,
         })
       );


### PR DESCRIPTION
…ng order_referecence_number that has been removed from the order model, but using the paymentId instead